### PR TITLE
BB-1056: Update BitOasis commons package

### DIFF
--- a/src/BitOasis/Common/Console/ConsoleUtils.php
+++ b/src/BitOasis/Common/Console/ConsoleUtils.php
@@ -70,6 +70,26 @@ class ConsoleUtils {
 			self::PAIR => 'EOS-BTC',
 			self::SYMBOL => 'tEOSBTC',
 		],
+		'omgbtc' => [
+			self::DESCRIPTION => 'OMG-BTC',
+			self::PAIR => 'OMG-BTC',
+			self::SYMBOL => 'tOMGBTC',
+		],
+		'zrxbtc' => [
+			self::DESCRIPTION => 'ZRX-BTC',
+			self::PAIR => 'ZRX-BTC',
+			self::SYMBOL => 'tZRXBTC',
+		],
+		'batbtc' => [
+			self::DESCRIPTION => 'BAT-BTC',
+			self::PAIR => 'BAT-BTC',
+			self::SYMBOL => 'tBATBTC',
+		],
+		'algbtc' => [
+			self::DESCRIPTION => 'ALG-BTC',
+			self::PAIR => 'ALG-BTC',
+			self::SYMBOL => 'tALGBTC',
+		],
 		'xrpaed' => [
 			self::DESCRIPTION => 'XRP',
 			self::PAIR => 'XRP-AED',
@@ -109,6 +129,26 @@ class ConsoleUtils {
 			self::DESCRIPTION => 'EOS',
 			self::PAIR => 'EOS-AED',
 			self::SYMBOL => 'tEOSUSD',
+		],
+		'omgaed' => [
+			self::DESCRIPTION => 'OMG',
+			self::PAIR => 'OMG-AED',
+			self::SYMBOL => 'tOMGUSD',
+		],
+		'zrxaed' => [
+			self::DESCRIPTION => 'ZRX',
+			self::PAIR => 'ZRX-AED',
+			self::SYMBOL => 'tZRXUSD',
+		],
+		'bataed' => [
+			self::DESCRIPTION => 'BAT',
+			self::PAIR => 'BAT-AED',
+			self::SYMBOL => 'tBATUSD',
+		],
+		'algaed' => [
+			self::DESCRIPTION => 'ALG',
+			self::PAIR => 'ALG-AED',
+			self::SYMBOL => 'tALGUSD',
 		],
 	];
 

--- a/src/BitOasis/Common/CurrencyPair/CurrencyCodePair.php
+++ b/src/BitOasis/Common/CurrencyPair/CurrencyCodePair.php
@@ -40,9 +40,22 @@ class CurrencyCodePair implements Pair {
 
 		'EOS-AED' => 'EOS-AED',
 		'EOS-BTC' => 'EOS-BTC',
+		'EOS-ETH' => 'EOS-ETH',
 
 		'BSV-AED' => 'BSV-AED',
 		'BSV-BTC' => 'BSV-BTC',
+
+		'OMG-AED' => 'OMG-AED',
+		'OMG-BTC' => 'OMG-BTC',
+
+		'ZRX-AED' => 'ZRX-AED',
+		'ZRX-BTC' => 'ZRX-BTC',
+
+		'BAT-AED' => 'BAT-AED',
+		'BAT-BTC' => 'BAT-BTC',
+
+		'ALG-AED' => 'ALG-AED',
+		'ALG-BTC' => 'ALG-BTC',
 	];
 	const VALID_PAIRS = [
 		'BTC-AED', 'BTC-USD', 'BTC-KWD',
@@ -72,9 +85,22 @@ class CurrencyCodePair implements Pair {
 
 		'EOS-AED', 'EOS-USD',
 		'EOS-BTC',
+		'EOS-ETH',
 
 		'BSV-AED', 'BSV-USD',
 		'BSV-BTC',
+
+		'OMG-AED', 'OMG-USD',
+		'OMG-BTC',
+
+		'ZRX-AED', 'ZRX-USD',
+		'ZRX-BTC',
+
+		'BAT-AED', 'BAT-USD',
+		'BAT-BTC',
+
+		'ALG-AED', 'ALG-USD',
+		'ALG-BTC',
 	];
 	const FIAT_CRYPTOCURRENCY_CODES = ['USD', 'AED'];
 	const VALID_BASE_CRYPTOCURRENCIES = ['USD', 'AED', 'BTC', 'ETH'];


### PR DESCRIPTION
added BTC and AED based pairs for OMG, ZRX, ABT and ALG cryptocurrencies as well as EOS-ETH pair

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bit-oasis/bitoasis-common/5)
<!-- Reviewable:end -->
