### PR TITLE
Bring back XLM-ETH and NEO-ETH as VALID_PAIRS

### DIFF
--- a/src/BitOasis/Common/CurrencyPair/CurrencyCodePair.php
+++ b/src/BitOasis/Common/CurrencyPair/CurrencyCodePair.php
@@ -511,6 +511,7 @@ class CurrencyCodePair implements Pair {
 
 		'XLM-AED', 'XLM-SAR', 'XLM-TRY', 'XLM-USD',
 		'XLM-USDT', 'XLM-BTC',
+		'XLM-ETH' => 'XLM-ETH', // De-listed (keeping for historical support)
 
 		'EOS-AED', 'EOS-SAR', 'EOS-TRY', 'EOS-USD',
 		'EOS-USDT', 'EOS-BTC', 'EOS-ETH',
@@ -534,6 +535,7 @@ class CurrencyCodePair implements Pair {
 
 		'NEO-AED', 'NEO-SAR', 'NEO-TRY', 'NEO-USD',
 		'NEO-USDT', 'NEO-BTC',
+		'NEO-ETH' => 'NEO-ETH', // De-listed (keeping for historical support)
 
 		'XTZ-AED', 'XTZ-SAR', 'XTZ-TRY', 'XTZ-USD',
 		'XTZ-USDT', 'XTZ-BTC',


### PR DESCRIPTION
Bring back XLM-ETH and NEO-ETH as VALID_PAIRS (need for supporting historical data)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bit-oasis/bitoasis-common/16)
<!-- Reviewable:end -->
